### PR TITLE
Add proxy support

### DIFF
--- a/raiapi.js
+++ b/raiapi.js
@@ -47,6 +47,7 @@ class RaiApi {
             headers: {
                 'User-Agent': null,
             },
+            proxy: process.env.HTTP_PROXY,
             url: url,
         }, (error, response) => {
             if (error || response.error || response.statusCode != 302) {


### PR DESCRIPTION
When deployed outside of Italy existing BE can have problem retrieving the actual URLs so it's necessary to use a proxy