### PR TITLE
Reduce TTL

### DIFF
--- a/raiapi.js
+++ b/raiapi.js
@@ -247,7 +247,7 @@ class RaiApi {
                     const programmi = _.values(body[this.channelMap[canale]][`${m.format('YYYY-MM-DD')}`]);
 
                     if (programmi.length > 0 && this.redisClient && this.redisClient.connected) {
-                        this.redisClient.set(redisKey, JSON.stringify(programmi), 'EX', 86400 * 7);
+                        this.redisClient.set(redisKey, JSON.stringify(programmi), 'EX', 1800); //30 minutes
                     }
 
                     callback(null, programmi);


### PR DESCRIPTION
Caching the initial data for (up to) seven days can lead to malfunctioning.
Data is updated during the first day after broadcast so cache can have some URL missing.
We need then to invalidate the cache and reload original data in order to refresh it.