### PR TITLE
Improve url detection

### DIFF
--- a/raiapi.js
+++ b/raiapi.js
@@ -49,7 +49,7 @@ class RaiApi {
     static getEffectiveUrl(url, qualita, useProxy, callback) {
         request.get({
             headers: {
-                'User-Agent': null,
+                'User-Agent': 'raiweb',
             },
             proxy: useProxy ? process.env.HTTP_PROXY_RAI : undefined,
             url: url,


### PR DESCRIPTION
Relinker Servlet gives direct MP4 url if request contains a specific user agent header.
This way we can avoid decoding.