### PR TITLE
Simplify Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .idea/
-node_modules/
 .dockerignore
 docker-compose.yml
 now.json

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Docker build
       uses: docker/build-push-action@v6
       with:
-        tags: maxcanna/raiapi:latest
+        tags: maxcanna/raiapi:latest,maxcanna/raiapi:${{ env.VERSION_NUMBER }}
         labels: version=$VERSION_NUMBER
         push: ${{ env.DOCKER_PUSH }}
         platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,7 @@ jobs:
       run: |
         echo DOCKER_PUSH=$([[ $GITHUB_REF == *"master"* ]] && echo "true" || echo "false") >> $GITHUB_ENV
         echo VERSION_NUMBER=$(jq -r < package.json .version) >> $GITHUB_ENV
+        echo NODE_ENV=production >> $GITHUB_ENV
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
@@ -21,6 +22,20 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Setup node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18
+    - name: Install yarn
+      run: npm install --global --force yarn@1.22.22
+    - name: Install dev dependencies
+      run: yarn install --production=false
+    - name: Build application
+      run: yarn build
+    - name: Delete node_modules
+      run: rm -rf node_modules
+    - name: Install dependencies
+      run: yarn install
     - name: Docker build
       uses: docker/build-push-action@v6
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,7 @@
-FROM node:18-alpine AS be
-ADD ./ /var/www/raiapi/
-WORKDIR /var/www/raiapi
-RUN rm -rf src
-ENV NODE_ENV=production
-RUN npm install --global --force yarn@1.22.22
-RUN yarn install --network-timeout 1000000000
-
-FROM node:18-alpine AS fe
-ADD ./ /var/www/raiapi/
-WORKDIR /var/www/raiapi
-RUN npm install --global --force yarn@1.22.22
-RUN yarn install --network-timeout 1000000000
-ENV NODE_ENV=production
-RUN yarn build
-
 FROM node:18-alpine
 LABEL org.opencontainers.image.authors="massi@massi.dev"
 WORKDIR /var/www/raiapi
-COPY --from=be /var/www/raiapi .
-COPY --from=fe /var/www/raiapi/public public/
+COPY ./ .
 RUN npm install --global --force yarn@1.22.22
 ENV NODE_ENV=production
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM node:18-alpine
 LABEL org.opencontainers.image.authors="massi@massi.dev"
 WORKDIR /var/www/raiapi
 COPY ./ .
-RUN npm install --global --force yarn@1.22.22
 ENV NODE_ENV=production
 EXPOSE 3000
-CMD ["yarn", "start"]
+CMD ["node", "index.js"]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "yarn": "1.22.22"
   },
   "name": "raiapi",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "RaiPlay API",
   "private": true,
   "main": "index.js",


### PR DESCRIPTION
Simplify Docker build and integrate build steps into GitHub Actions

- `Dockerfile`:
  - Removed the initial `be` and `fe` build stages.
  - Modified the remaining stage to copy all necessary files from the local build context directly, including source code, compiled assets, and `node_modules`, which are now prepared by the GitHub Actions workflow.
  - Removed the need for yarn using node to start the server

- `.github/workflows/docker.yml`:
  - Added steps after Docker login and before Docker build to:
    - Set up Node.js v18.
    - Install a specific version of Yarn (1.22.22).
    - Run `yarn install` to fetch dependencies.
    - Run `yarn build` with `NODE_ENV=production` to create the production build.

This change streamlines the Docker image creation process by leveraging the GitHub Actions environment for building the application, resulting in a simpler Dockerfile and a more explicit build process within the CI/CD pipeline.